### PR TITLE
Update iothub-client-core-ll-h.md

### DIFF
--- a/iothub-client-core-ll-h.md
+++ b/iothub-client-core-ll-h.md
@@ -13,7 +13,9 @@ ms.topic: "reference"
 
 # iothub_client_core_ll.h 
 
-APIs that allow a user (usually a device) to communicate with an Azure IoTHub.
+Internal APIs used by the Azure IoT C SDK to communicate with an Azure IoTHub.
+
+Direct use of this library header is not supported.
 
 ## Includes
 


### PR DESCRIPTION
Update documentation to make it clear that iothub_client_core_ll.h must not be used directly by users.