### PR TITLE
Update iothub-client-core-h.md

### DIFF
--- a/iothub-client-core-h.md
+++ b/iothub-client-core-h.md
@@ -30,6 +30,10 @@ IoTHubClientCore is a module that extends the IoTHubClientCore_LL module with 2 
 
 * thread-safe APIs
 
+This is an internal APIs used by the Azure IoT C SDK to communicate with an Azure IoTHub.
+
+Direct use of this library header is not supported.
+
 ## Functions
 
 Function Name                  | Description                                


### PR DESCRIPTION
Update documentation to make it clear that iothub_client_core.h must not be used directly by users.